### PR TITLE
Add missing dependency for types

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,20 +39,20 @@
     "index.js"
   ],
   "dependencies": {
+    "mdast-util-from-markdown": "^1.0.0",
     "mdast-util-gfm-autolink-literal": "^1.0.0",
     "mdast-util-gfm-footnote": "^1.0.0",
     "mdast-util-gfm-strikethrough": "^1.0.0",
     "mdast-util-gfm-table": "^1.0.0",
-    "mdast-util-gfm-task-list-item": "^1.0.0"
+    "mdast-util-gfm-task-list-item": "^1.0.0",
+    "mdast-util-to-markdown": "^1.0.0"
   },
   "devDependencies": {
     "@types/tape": "^4.0.0",
     "c8": "^7.0.0",
     "github-slugger": "^1.0.0",
     "hast-util-to-html": "^8.0.0",
-    "mdast-util-from-markdown": "^1.0.0",
     "mdast-util-to-hast": "^12.0.0",
-    "mdast-util-to-markdown": "^1.0.0",
     "micromark-extension-gfm": "^2.0.0",
     "node-fetch": "^3.0.0",
     "prettier": "^2.0.0",


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Fix these build errors:

```
ERROR in ../../.yarn/cache/mdast-util-gfm-npm-2.0.0-177231f942-70c35ee810.zip/node_modules/mdast-util-gfm/index.d.ts 12:44-70
TS2307: Cannot find module 'mdast-util-from-markdown' or its corresponding type declarations.
    10 |   options?: import('mdast-util-gfm-table').Options | undefined
    11 | ): ToMarkdownExtension
  > 12 | export type FromMarkdownExtension = import('mdast-util-from-markdown').Extension
       |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
    13 | export type ToMarkdownExtension = import('mdast-util-to-markdown').Options
    14 | export type Options = import('mdast-util-gfm-table').Options
    15 |

ERROR in ../../.yarn/cache/mdast-util-gfm-npm-2.0.0-177231f942-70c35ee810.zip/node_modules/mdast-util-gfm/index.d.ts 13:42-66
TS2307: Cannot find module 'mdast-util-to-markdown' or its corresponding type declarations.
    11 | ): ToMarkdownExtension
    12 | export type FromMarkdownExtension = import('mdast-util-from-markdown').Extension
  > 13 | export type ToMarkdownExtension = import('mdast-util-to-markdown').Options
       |                                          ^^^^^^^^^^^^^^^^^^^^^^^^
    14 | export type Options = import('mdast-util-gfm-table').Options
    15 |
```

<!--do not edit: pr-->
